### PR TITLE
Hotfix/regex fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,7 +346,7 @@ checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "hunter"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hunter"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 rust-version = "1.74.0"
 authors = ["Nick Furfaro <furnic@skiff.com>"]

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -3,7 +3,7 @@ use regex::Regex;
 
 pub fn test_regex(language: &Language) -> Regex {
     match language {
-        Language::Noir => Regex::new(r"#\[test(\(\))?\]\s+fn\s+\w+\(\)\s*\{[^}]*\}").unwrap(),
+        Language::Noir => Regex::new(r"#\[test(\(.*\))?\]\s+fn\s+\w+\(\)\s*\{[^}]*\}").unwrap(),
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -180,7 +180,7 @@ mod tests {
         let pattern = test_regex(&Language::Noir);
         assert_eq!(
             pattern.as_str(),
-            r"#\[test(\(\))?\]\s+fn\s+\w+\(\)\s*\{[^}]*\}"
+            r"#\[test(\(.*\))?\]\s+fn\s+\w+\(\)\s*\{[^}]*\}"
         );
     }
 


### PR DESCRIPTION
Fix the regex filter to match tests win non-empty parens, i.e:

#[test(should_fail)]